### PR TITLE
Fix not functioning when forms enable

### DIFF
--- a/Etch.OrchardCore.OutputCache.csproj
+++ b/Etch.OrchardCore.OutputCache.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.0-alpha</Version>
+    <Version>0.1.1-alpha</Version>
     <PackageId>Etch.OrchardCore.OutputCache</PackageId>
     <Title>Output Caching</Title>
     <Authors>Etch UK Ltd.</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Performance",
     Description = "Provides caching using Output Cache.",
     Name = "Output Caching",
-    Version = "0.1.0",
+    Version = "0.1.1",
     Website = "https://etchuk.com"
 )]
 

--- a/Policies/DefaultOrchardCorePolicy.cs
+++ b/Policies/DefaultOrchardCorePolicy.cs
@@ -1,0 +1,94 @@
+﻿using Azure;
+using Etch.OrchardCore.OutputCache.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.OutputCache.Policies
+{
+    public class DefaultOrchardCorePolicy : IOutputCachePolicy
+    {
+        private readonly OutputCacheSettings _settings;
+
+        public DefaultOrchardCorePolicy(OutputCacheSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public ValueTask CacheRequestAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            var attemptOutputCaching = AttemptOutputCaching(context);
+            context.EnableOutputCaching = true;
+            context.AllowCacheLookup = attemptOutputCaching;
+            context.AllowCacheStorage = attemptOutputCaching;
+            context.AllowLocking = true;
+
+            // Vary by any query by default
+            context.CacheVaryByRules.QueryKeys = "*";
+
+            if (_settings.VaryByQueryStrings.Any())
+            {
+                context.CacheVaryByRules.QueryKeys = _settings.VaryByQueryStrings;
+            }
+
+            if (string.IsNullOrWhiteSpace(_settings.Tag))
+            {
+                context.Tags.Add(_settings.Tag);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ServeFromCacheAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ServeResponseAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            var response = context.HttpContext.Response;
+
+            // Verify existence of cookie headers
+            if (!StringValues.IsNullOrEmpty(response.Headers.SetCookie) && 
+                response.Headers.SetCookie.Count != 1 &&
+                !response.Headers.SetCookie[0].StartsWith(".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT;"))
+            {
+                context.AllowCacheStorage = false;
+                return ValueTask.CompletedTask;
+            }
+
+            // Check response code
+            if (response.StatusCode != StatusCodes.Status200OK)
+            {
+                context.AllowCacheStorage = false;
+                return ValueTask.CompletedTask;
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        private static bool AttemptOutputCaching(OutputCacheContext context)
+        {
+            // Check if the current request fulfisls the requirements to be cached
+
+            var request = context.HttpContext.Request;
+
+            // Verify the method
+            if (!HttpMethods.IsGet(request.Method) && !HttpMethods.IsHead(request.Method))
+            {
+                return false;
+            }
+
+            // Verify existence of authorization headers
+            if (!StringValues.IsNullOrEmpty(request.Headers.Authorization) || request.HttpContext.User?.Identity?.IsAuthenticated == true)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,6 @@
 using Etch.OrchardCore.OutputCache.Controllers;
 using Etch.OrchardCore.OutputCache.Drivers;
+using Etch.OrchardCore.OutputCache.Policies;
 using Etch.OrchardCore.OutputCache.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -38,14 +39,7 @@ namespace Etch.OrchardCore.OutputCache
 
                 options.DefaultExpirationTimeSpan = new TimeSpan(0, settings.Expiration, 0);
 
-                options.AddBasePolicy(build => {
-                    build.Tag(settings.Tag);
-
-                    if (settings.VaryByQueryStrings != null)
-                    {
-                        build.VaryByQuery(settings.VaryByQueryStrings);
-                    }
-                });
+                options.AddBasePolicy(new DefaultOrchardCorePolicy(settings));
             });
         }
 


### PR DESCRIPTION
Issue was due to a filter in the forms module that accesses `TempData` which sets a cookie. Added a custom policy that will check whether the cookie being set is an expired temp data cookie and if so it'll serve the response from the cache.